### PR TITLE
[OAWeather] update documentation

### DIFF
--- a/README
+++ b/README
@@ -135,7 +135,7 @@ These arguments are depending of the day argument:
 temperature_heigh      # Example: "9 °C"
 temperature_low        # Example: "6 °C"
 temperature_heigh_low  # Example: "6 - 9 °C"
-temperature_text       # Example: "rain showers", HINT: OpenMeteo doesn't deliver descriptions, therefore "N/A" comes up
+temperature_text       # Example: "rain showers", HINT: OpenMeteo doesn't deliver descriptions, an empty string is now supplied (instead of "N/A")
 weekday                # Example: "Friday"
 weekshortday           # Example: "Fr"
 date                   # Example: "2023-01-13"


### PR DESCRIPTION
- OpenMeteo doesn't deliver descriptions, an empty string is now supplied (instead of "N/A")